### PR TITLE
added dice_bag template and simplify requirements of gems

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,11 @@
 = RubyCAS-Client Changelog
 
+== Version 2.2.3 :: 2013-04-29
+* Added dicebag template
+
+== Version 2.2.2 :: 2013-02-07
+* Avoid mass assignment errors
+
 == Version 2.2.1 :: 2011-01-04
 * Added support for Rails 3
 

--- a/lib/casclient.rb
+++ b/lib/casclient.rb
@@ -67,6 +67,7 @@ require 'casclient/tickets'
 require 'casclient/responses'
 require 'casclient/client'
 require 'casclient/version'
+require 'casclient/dice_bag/cas_templates'
 
 # Detect legacy configuration and show appropriate error message
 module CAS

--- a/lib/casclient/dice_bag/cas.yml.dice
+++ b/lib/casclient/dice_bag/cas.yml.dice
@@ -1,0 +1,5 @@
+<% [ :production, :development, :test ].each do |env| %> 
+<%= env %>:
+  cas_domain: <%= configured[env].cas_domain || 'localhost' %>
+  cas_base_url: <%= configured[env].cas_base_url || 'http://localhost:7890' %>
+<% end %>

--- a/lib/casclient/dice_bag/cas_templates.rb
+++ b/lib/casclient/dice_bag/cas_templates.rb
@@ -1,0 +1,9 @@
+require 'dice_bag'
+
+class CasClientTemplate < DiceBag::AvailableTemplates
+  def templates
+    ['cas.yml.dice'].map do |template|
+      File.join(File.dirname(__FILE__), template)
+    end
+  end
+end

--- a/lib/casclient/version.rb
+++ b/lib/casclient/version.rb
@@ -2,7 +2,7 @@ module CASClient #:nodoc:
   module VERSION #:nodoc:
     MAJOR = 2
     MINOR = 2
-    TINY  = 2
+    TINY  = 3
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/rubycas-client.gemspec
+++ b/rubycas-client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{rubycas-client}
-  s.version = "2.2.2"
+  s.version = "2.2.3"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Matt Zukowski", "Matt Walker"]
@@ -18,19 +18,8 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.2.0}
   s.summary = %q{Client library for the Central Authentication Service (CAS) protocol.}
 
-  if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
-    s.specification_version = 2
+  s.add_runtime_dependency(%q<activesupport>, [">= 0"])
+  s.add_development_dependency(%q<hoe>, [">= 1.7.0"])
+  s.add_dependency 'dice_bag', '~> 0.6' 
 
-    if current_version >= 3 then
-      s.add_runtime_dependency(%q<activesupport>, [">= 0"])
-      s.add_development_dependency(%q<hoe>, [">= 1.7.0"])
-    else
-      s.add_dependency(%q<activesupport>, [">= 0"])
-      s.add_dependency(%q<hoe>, [">= 1.7.0"])
-    end
-  else
-    s.add_dependency(%q<activesupport>, [">= 0"])
-    s.add_dependency(%q<hoe>, [">= 1.7.0"])
-  end
 end


### PR DESCRIPTION


Added the templates we had in dice_bag-mdsol to this gem instead.

I've done this so any time this gem is modified in any way or we want to improve its configuration, we can do it all in this repository. I think it makes more sense.

Similar PRs have been merged for Eureka-client and mauth-client. Once this is merged we will not need dice_bag-mdsol and I'll make a PR there to point to use cas-client >= 2.2.3

I've tested these changes locally and it works.

I've also deleted some clutter from the gemspec file, we do not need that since 2009 or so. Tested and the gem builds correctly.
