### PR TITLE
add dice_bag template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 = RubyCAS-Client Changelog
 
+== Version 2.3.11 :: 2016-01-27
+* New functionality
+  * Add dice-bag template
+
 == Version 2.3.10 :: 2015-11-23
 * New functionality
   * Add support for Rails 4 applications

--- a/lib/casclient.rb
+++ b/lib/casclient.rb
@@ -3,6 +3,7 @@ require 'cgi'
 require 'logger'
 require 'net/https'
 require 'rexml/document'
+require 'casclient/dice_bag/cas_template'
 
 begin
   require 'active_support'

--- a/lib/casclient/dice_bag/cas.yml.dice
+++ b/lib/casclient/dice_bag/cas.yml.dice
@@ -1,0 +1,5 @@
+<% [ :production, :development, :test ].each do |env| %>
+<%= env %>:
+  cas_domain: <%= configured[env].cas_domain || 'localhost' %>
+  cas_base_url: <%= configured[env].cas_base_url || 'http://localhost:7890' %>
+<% end %>

--- a/lib/casclient/dice_bag/cas_template.rb
+++ b/lib/casclient/dice_bag/cas_template.rb
@@ -1,0 +1,9 @@
+require 'dice_bag'
+
+class CasClientTemplate < DiceBag::AvailableTemplates
+  def templates
+    ['cas.yml.dice'].map do |template|
+      File.join(File.dirname(__FILE__), template)
+    end
+  end
+end

--- a/lib/casclient/version.rb
+++ b/lib/casclient/version.rb
@@ -2,7 +2,7 @@ module CASClient #:nodoc:
   module VERSION #:nodoc:
     MAJOR = 2
     MINOR = 3
-    TINY  = 10
+    TINY  = 11
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/rubycas-client.gemspec
+++ b/rubycas-client.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rubycas-client"
-  s.version = "2.3.9"
+  s.version = "2.3.11"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Matt Zukowski", "Matt Walker", "Matt Campbell"]
@@ -91,6 +91,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<activesupport>, [">= 0"])
+      s.add_runtime_dependency 'dice_bag', '>= 0.9', '< 2.0'
       s.add_development_dependency(%q<json>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<bundler>, [">= 1.0"])


### PR DESCRIPTION
This is the last step so we can deprecate dice_bag-mdsol.
It makes sense that gems bring their own configuration
@CGDS 