### PR TITLE
[MCC-218610] Add a method returning the activity tracker update interval 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 = RubyCAS-Client Changelog
 
-== Version 2.3.13 :: 2016-03-14
+== Version 2.3.13 :: 2016-03-23
 * New functionality
   * Add the ability to set any top-level session attribute for the fake user.
+  * Add method returning the activity tracker update interval from the CAS extra attributes.
 
 == Version 2.3.12 :: 2016-03-11
 * New functionality

--- a/lib/casclient/frameworks/rails/filter.rb
+++ b/lib/casclient/frameworks/rails/filter.rb
@@ -13,6 +13,7 @@ module CASClient
         @@fake_user = nil
         @@fake_extra_attributes = nil
         DEFAULT_TIMEOUT = 30.minutes
+        DEFAULT_ACTIVITY_TRACKER_UPDATE_INTERVAL = 15.minutes
         
         class << self
           # Needed for the reasons in this issue:
@@ -285,6 +286,14 @@ module CASClient
               (controller.session[client.extra_attributes_session_key][:timeout] || DEFAULT_TIMEOUT).to_i
             else
               DEFAULT_TIMEOUT
+            end
+          end
+
+          def activity_tracker_update_interval(controller)
+            if controller.session[client.extra_attributes_session_key]
+              (controller.session[client.extra_attributes_session_key][:updateIntervalSeconds] || DEFAULT_ACTIVITY_TRACKER_UPDATE_INTERVAL).to_i
+            else
+              DEFAULT_ACTIVITY_TRACKER_UPDATE_INTERVAL
             end
           end
 

--- a/spec/casclient/frameworks/rails/filter_spec.rb
+++ b/spec/casclient/frameworks/rails/filter_spec.rb
@@ -192,4 +192,13 @@ describe CASClient::Frameworks::Rails::Filter do
       CASClient::Frameworks::Rails::Filter.auto_session_timeout(controller).should eq(1800)
     end
   end
+
+  context 'controller request activity tracker update interval' do
+    subject { Hash.new }
+    it 'should return an activity tracker update interval' do
+      subject[:cas_extra_attributes] = { updateIntervalSeconds: '900' }
+      controller = mock_controller_with_session(nil, subject)
+      expect(CASClient::Frameworks::Rails::Filter.activity_tracker_update_interval(controller)).to eq(900)
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a method returning the activity tracker update interval from the CAS extra attributes.  CAS has recently been updated to provide the activity tracker update interval in the extra attributes (https://github.com/mdsol/authmedidata/pull/384).

@sakhtermdsol 