### PR TITLE
[MCC-485275] Move Initializer in iMedidata into Gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ pkg
 .rvmrc
 
 .project
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # RubyCAS-Client Changelog
 
+## 3.0.2
+* Other
+  * Stray initializer for memcached sessions leftover in consuming app moved into gem.
+
 ## 3.0.1
 * Bug fixes
   * Use the version declared in `lib/casclient/version.rb` instead of hardcoding it in the gemspec file.

--- a/lib/active_model_memcache_store.rb
+++ b/lib/active_model_memcache_store.rb
@@ -1,0 +1,57 @@
+require 'action_dispatch/middleware/session/abstract_store'
+require 'action_dispatch/middleware/session/dalli_store'
+require 'active_support/cache/dalli_store.rb'
+
+module ActionDispatch
+  module Session
+    # A session store that uses an ActiveSupport::Cache::Store to store the sessions. This store is most useful
+    # if you don't store critical data in your sessions and you don't need them to live for extended periods
+    # of time.
+    #
+    # ==== Options
+    # * <tt>cache</tt>         - The cache to use. If it is not specified, <tt>Rails.cache</tt> will be used.
+    # * <tt>expire_after</tt>  - The length of time a session will be stored before automatically expiring.
+    #   By default, the <tt>:expires_in</tt> option of the cache is used.
+    class ActiveModelMemcacheStore < ActionDispatch::Session::DalliStore
+
+      def set_session(env, sid, session_data, options = nil)
+        if @pool.exist?(sid)
+          session = @pool.get(sid)
+          # Copy session_id and service_ticket into the session_data
+          %w(session_id service_ticket).each { |key| session_data[key] = session[key] if session[key] }
+        end
+        super(env, sid, session_data, options)
+      end
+
+      # The service ticket is also being stored in Memcache in the form -
+      # service_ticket => session_id
+      # session_id => {session_data}
+      # Need to ensure that when a session is being destroyed - we also clean up the service-ticket
+      # related data prior to letting the session be destroyed.
+      def destroy_session(env, session_id, options)
+        if @pool.exist?(session_id)
+          session = @pool.get(session_id)
+          if session.has_key?("service_ticket") && @pool.exist?(session["service_ticket"])
+            begin
+              @pool.delete(session["service_ticket"])
+            rescue Dalli::DalliError
+              Rails.logger.warn("Session::DalliStore#destroy_session: #{$!.message}")
+              raise if @raise_errors
+            end
+          end
+        end
+        super(env, session_id, options)
+      end
+
+    end
+  end
+end
+
+module ActiveSupport
+  module Cache
+    class DalliStore
+      alias_method :get, :read
+      alias_method :set, :write
+    end
+  end
+end

--- a/lib/casclient.rb
+++ b/lib/casclient.rb
@@ -4,6 +4,7 @@ require 'logger'
 require 'net/https'
 require 'rexml/document'
 require 'casclient/dice_bag/cas_template'
+require 'active_model_memcache_store'
 
 begin
   require 'active_support'

--- a/lib/casclient/version.rb
+++ b/lib/casclient/version.rb
@@ -1,3 +1,3 @@
 module CASClient #:nodoc:
-  VERSION = '3.0.1'.freeze
+  VERSION = '3.0.2'.freeze
 end


### PR DESCRIPTION
This moves [this initializer in iMedidata](https://github.com/mdsol/imedidata/blob/develop/config/initializers/active_model_memcache_store.rb) into the rubycas gem, where it should have been to begin with. Otherwise consumers using memcache session functionality have to include both the gem and that initializer. 

Not quite ready for review. Testing out in sandbox.