### PR TITLE
[MCC-485275] Fix actiondispatch/rack issue 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # RubyCAS-Client Changelog
 
+## 3.1.0
+* Other
+  * support rails 5/rack 2.0. Memcached session support introduced in 3.0.2 updated to work with rails 5.
+
 ## 3.0.2
 * Other
   * Stray initializer for memcached sessions leftover in consuming app moved into gem.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # RubyCAS-Client Changelog
 
-## 3.1.0
+## 3.0.3
 * Other
   * support rails 5/rack 2.0. Memcached session support introduced in 3.0.2 updated to work with Rails 5.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.1.0
 * Other
-  * support rails 5/rack 2.0. Memcached session support introduced in 3.0.2 updated to work with rails 5.
+  * support rails 5/rack 2.0. Memcached session support introduced in 3.0.2 updated to work with Rails 5.
 
 ## 3.0.2
 * Other

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubycas-client (3.0.2)
+    rubycas-client (3.0.3)
       activesupport
       dalli (>= 2.0)
       dice_bag (>= 0.9, < 2.0)
@@ -34,7 +34,7 @@ GEM
     builder (3.0.4)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
-    dalli (2.7.8)
+    dalli (2.7.10)
     database_cleaner (0.9.1)
     dice_bag (1.3.3)
       diff-lcs (~> 1.0)
@@ -144,4 +144,4 @@ DEPENDENCIES
   sqlite3 (~> 1.3)
 
 BUNDLED WITH
-   1.16.4
+   1.16.6

--- a/lib/active_model_memcache_store.rb
+++ b/lib/active_model_memcache_store.rb
@@ -43,6 +43,11 @@ module ActionDispatch
         super(env, session_id, options)
       end
 
+      # Patch Rack 2.0 changes that broke ActionDispatch.
+      alias_method :find_session, :get_session
+      alias_method :write_session, :set_session
+      alias_method :delete_session, :destroy_session
+
     end
   end
 end
@@ -52,17 +57,6 @@ module ActiveSupport
     class DalliStore
       alias_method :get, :read
       alias_method :set, :write
-    end
-  end
-end
-
-# Patch Rack 2.0 changes that broke ActionDispatch.
-module ActionDispatch
-  module Session
-    class DalliStore < AbstractStore
-      alias_method :find_session, :get_session
-      alias_method :write_session, :set_session
-      alias_method :delete_session, :destroy_session
     end
   end
 end

--- a/lib/active_model_memcache_store.rb
+++ b/lib/active_model_memcache_store.rb
@@ -55,3 +55,14 @@ module ActiveSupport
     end
   end
 end
+
+# Patch Rack 2.0 changes that broke ActionDispatch.
+module ActionDispatch
+  module Session
+    class DalliStore < AbstractStore
+      alias_method :find_session, :get_session
+      alias_method :write_session, :set_session
+      alias_method :delete_session, :destroy_session
+    end
+  end
+end

--- a/lib/casclient/version.rb
+++ b/lib/casclient/version.rb
@@ -1,3 +1,3 @@
 module CASClient #:nodoc:
-  VERSION = '3.0.2'.freeze
+  VERSION = '3.1.0'.freeze
 end

--- a/lib/casclient/version.rb
+++ b/lib/casclient/version.rb
@@ -1,3 +1,3 @@
 module CASClient #:nodoc:
-  VERSION = '3.1.0'.freeze
+  VERSION = '3.0.3'.freeze
 end


### PR DESCRIPTION
This appears to work for checkmate with it's migration to rails 5. Checkmate is currently deployed with this branch in sandbox with no issues observed (yet). iMedidata will presumably need this once it moves up to rails 5 as well.

I bumped minor version here to 3.1.0 since this marks a change but the final tag number is negotiable.

Question is whether we want to have this mark it as "don't upgrade to this gem version until on rails 5..." or ensure that this would still work for rails 4 apps that want to use memcache. 
i'm inclined to the first option.

This may in fact work for rails 4 since the aliases may not break anything.

@clabrunda @cwhite-mdsol @mdsol/team-07 
