### PR TITLE
Fix for quote session id issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
 
 before_install:
   - gem update --system
-  - bundle update --bundler
+  - gem install bundler -v $(tail -n1 Gemfile.lock)
 
 script:
   - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
 
 before_install:
   - gem update --system
+  - bundle update --bundler
 
 script:
   - bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # RubyCAS-Client Changelog
 
+## 3.0.4
+* Other
+  * Cast session.id to string as with Rails 5.2+ it is of type Rack::Session::SessionId.
+
 ## 3.0.3
 * Other
   * support rails 5/rack 2.0. Memcached session support introduced in 3.0.2 updated to work with Rails 5.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubycas-client (3.0.3)
+    rubycas-client (3.0.4)
       activesupport
       dalli (>= 2.0)
       dice_bag (>= 0.9, < 2.0)
@@ -36,7 +36,7 @@ GEM
     concurrent-ruby (1.0.5)
     dalli (2.7.10)
     database_cleaner (0.9.1)
-    dice_bag (1.3.3)
+    dice_bag (1.3.4)
       diff-lcs (~> 1.0)
       rake
       thor (~> 0.0)
@@ -144,4 +144,4 @@ DEPENDENCIES
   sqlite3 (~> 1.3)
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/lib/casclient/tickets/storage.rb
+++ b/lib/casclient/tickets/storage.rb
@@ -64,7 +64,7 @@ module CASClient
         def session_id_from_controller(controller)
           session_id = controller.request.session_options[:id] || controller.session.session_id
           raise CASClient::CASException, "Failed to extract session_id from controller" if session_id.nil?
-          session_id
+          session_id&.public_id # See https://github.com/rails/rails/issues/38039
         end
       end
 

--- a/lib/casclient/tickets/storage.rb
+++ b/lib/casclient/tickets/storage.rb
@@ -62,9 +62,14 @@ module CASClient
         end
 
         def session_id_from_controller(controller)
-          session_id = controller.request.session_options[:id] || controller.session.session_id
+          session_id = nil
+          if controller.request.session_options[:id].present?
+            session_id = controller.request.session_options[:id].to_s
+          else
+            session_id = controller.session.session_id
+          end
           raise CASClient::CASException, "Failed to extract session_id from controller" if session_id.nil?
-          session_id&.public_id # See https://github.com/rails/rails/issues/38039
+          session_id
         end
       end
 

--- a/lib/casclient/tickets/storage/active_record_ticket_store.rb
+++ b/lib/casclient/tickets/storage/active_record_ticket_store.rb
@@ -36,7 +36,7 @@ module CASClient
             if new_session.save
               # Set the rack session record variable so the service doesn't create a duplicate session and instead updates
               # the data attribute appropriately.
-              controller.env['rack.session.record'] = new_session
+              controller.request.env['rack.session.record'] = new_session # For rails 5.1+, ActionController#env is deprecated
             else
               raise CASException, "Unable to store session #{session_id} for service ticket #{st} in the database."
             end

--- a/lib/casclient/tickets/storage/active_record_ticket_store.rb
+++ b/lib/casclient/tickets/storage/active_record_ticket_store.rb
@@ -36,7 +36,7 @@ module CASClient
             if new_session.save
               # Set the rack session record variable so the service doesn't create a duplicate session and instead updates
               # the data attribute appropriately.
-              controller.request.env['rack.session.record'] = new_session # For rails 5.1+, ActionController#env is deprecated
+              controller.env['rack.session.record'] = new_session
             else
               raise CASException, "Unable to store session #{session_id} for service ticket #{st} in the database."
             end

--- a/lib/casclient/version.rb
+++ b/lib/casclient/version.rb
@@ -1,3 +1,3 @@
 module CASClient #:nodoc:
-  VERSION = '3.0.3'.freeze
+  VERSION = '3.0.4'.freeze
 end

--- a/spec/casclient/tickets/storage_spec.rb
+++ b/spec/casclient/tickets/storage_spec.rb
@@ -3,6 +3,34 @@ require 'support/local_hash_ticket_store'
 require 'fileutils'
 
 describe CASClient::Tickets::Storage::AbstractTicketStore do
+  describe "#session_id_from_controller" do
+    it 'should return string session id from session options' do
+      stub = Object.new
+      session_id = 'mock_session_id'
+      stub.stub_chain(:request, :session_options).and_return({ id: session_id })
+      expect(subject.send(:session_id_from_controller, stub)).to eq(session_id)
+    end
+    it 'should cast session id to string from session options' do
+      stub = Object.new
+      session_id = 42
+      stub.stub_chain(:request, :session_options).and_return({ id: session_id })
+      expect(subject.send(:session_id_from_controller, stub)).to eq(session_id.to_s)
+    end
+    it 'should fallback to session object' do
+      stub = Object.new
+      session_id = 'mock_session_id'
+      stub.stub_chain(:request, :session_options).and_return({})
+      stub.stub_chain(:session, :session_id).and_return(session_id)
+      expect(subject.send(:session_id_from_controller, stub)).to eq(session_id)
+    end
+    it 'should raise exception when no session id is found' do
+      stub = Object.new
+      stub.stub_chain(:request, :session_options).and_return({})
+      stub.stub_chain(:session, :session_id).and_return(nil)
+      expect { subject.send(:session_id_from_controller, stub) }.to raise_error(CASClient::CASException)
+    end
+  end
+
   describe "#store_service_session_lookup" do
     it "should raise an exception" do
       expect { subject.store_service_session_lookup("service_ticket", mock_controller_with_session) }.to raise_exception 'Implement this in a subclass!'


### PR DESCRIPTION
Context:

I'm upgrading Patient Cloud Settings to Rails 5.2. While ad-hoc testing, I was unable to login and set session which lets us enter the app. When the session was being set or read, I got the following error TypeError - can't quote Rack::Session::SessionId

Fixes:

Use patch provided for quote error [here](https://github.com/rails/rails/issues/38039)