### PR TITLE
[MCC-619497] workaround to handle rack environment look up in rails 5 apps. spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # RubyCAS-Client Changelog
 
+## 3.0.5
+* Other
+  * Use controller.request instead of controller to set `.env` value for rack. Rails 5.1+ change.
+
 ## 3.0.4
 * Other
   * Cast session.id to string as with Rails 5.2+ it is of type Rack::Session::SessionId.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubycas-client (3.0.4)
+    rubycas-client (3.0.5)
       activesupport
       dalli (>= 2.0)
       dice_bag (>= 0.9, < 2.0)
@@ -36,10 +36,10 @@ GEM
     concurrent-ruby (1.0.5)
     dalli (2.7.10)
     database_cleaner (0.9.1)
-    dice_bag (1.3.4)
+    dice_bag (1.4.0)
       diff-lcs (~> 1.0)
       rake
-      thor (~> 0.0)
+      thor (< 2.0)
     diff-lcs (1.3)
     docile (1.1.5)
     erubis (2.7.0)

--- a/lib/casclient/tickets/storage/active_model_memcache_ticket_store.rb
+++ b/lib/casclient/tickets/storage/active_model_memcache_ticket_store.rb
@@ -27,8 +27,8 @@ module CASClient
             if new_session.save
               # Set the rack session record variable so the service doesn't create a duplicate session and instead updates
               # the data attribute appropriately.
-              (controller.respond_to?(:env) ? controller : controller.request)
-                .env['rack.session.record'] = new_session
+              obj_with_env = (controller.respond_to?(:env) ? controller : controller.request)
+              obj_with_env.env['rack.session.record'] = new_session
             else
               raise CASException, "Unable to store session #{session_id} for service ticket #{st} in the database."
             end

--- a/lib/casclient/tickets/storage/active_model_memcache_ticket_store.rb
+++ b/lib/casclient/tickets/storage/active_model_memcache_ticket_store.rb
@@ -27,7 +27,11 @@ module CASClient
             if new_session.save
               # Set the rack session record variable so the service doesn't create a duplicate session and instead updates
               # the data attribute appropriately.
-              controller.env['rack.session.record'] = new_session
+              if controller.respond_to?(:env)
+                controller.env['rack.session.record'] = new_session
+              else
+                controller.request.env['rack.session.record'] = new_session
+              end
             else
               raise CASException, "Unable to store session #{session_id} for service ticket #{st} in the database."
             end

--- a/lib/casclient/tickets/storage/active_model_memcache_ticket_store.rb
+++ b/lib/casclient/tickets/storage/active_model_memcache_ticket_store.rb
@@ -27,7 +27,7 @@ module CASClient
             if new_session.save
               # Set the rack session record variable so the service doesn't create a duplicate session and instead updates
               # the data attribute appropriately.
-              obj_with_env = (controller.respond_to?(:env) ? controller : controller.request)
+              obj_with_env = controller.respond_to?(:env) ? controller : controller.request
               obj_with_env.env['rack.session.record'] = new_session
             else
               raise CASException, "Unable to store session #{session_id} for service ticket #{st} in the database."

--- a/lib/casclient/tickets/storage/active_model_memcache_ticket_store.rb
+++ b/lib/casclient/tickets/storage/active_model_memcache_ticket_store.rb
@@ -27,11 +27,8 @@ module CASClient
             if new_session.save
               # Set the rack session record variable so the service doesn't create a duplicate session and instead updates
               # the data attribute appropriately.
-              if controller.respond_to?(:env)
-                controller.env['rack.session.record'] = new_session
-              else
-                controller.request.env['rack.session.record'] = new_session
-              end
+              (controller.respond_to?(:env) ? controller : controller.request)
+                .env['rack.session.record'] = new_session
             else
               raise CASException, "Unable to store session #{session_id} for service ticket #{st} in the database."
             end

--- a/lib/casclient/version.rb
+++ b/lib/casclient/version.rb
@@ -1,3 +1,3 @@
 module CASClient #:nodoc:
-  VERSION = '3.0.4'.freeze
+  VERSION = '3.0.5'.freeze
 end

--- a/spec/casclient/tickets/storage/active_model_memcache_ticket_store_spec.rb
+++ b/spec/casclient/tickets/storage/active_model_memcache_ticket_store_spec.rb
@@ -30,5 +30,18 @@ describe CASClient::Tickets::Storage::ActiveModelMemcacheTicketStore do
       subject.store_service_session_lookup(service_ticket, controller)
       subject.read_service_session_lookup(service_ticket).should eql("existing_session")
     end
+
+    it 'uses correct controller method to access rack session environment' do
+      controller = mock_controller_with_session
+      controller.stub_chain(:session, :session_id).and_return('existing_session')
+      controller.stub(:respond_to?) {false}
+      controller.stub_chain(:request, :env, :[]=)
+
+      @memcache_mock_store = {'existing_session' => {'service_ticket' => 'ST-id'}}
+
+      service_ticket = CASClient::ServiceTicket.new('ST-new', 'ActiveModelMemcacheTicketStore')
+      subject.store_service_session_lookup(service_ticket, controller)
+      subject.read_service_session_lookup(service_ticket).should eql('existing_session')
+    end
   end
 end


### PR DESCRIPTION
In rails 5.1+, `controller.env` was moved into the request object, iow `controller.request.env`. (some discussion in rails github [here](https://github.com/rails/rails/issues/23294))

Thus Checkmate, which is on rails 5.1.7 sees [a not infrequent error](https://jira.mdsol.com/browse/MCC-619497) in production when, for whatever reason, a session isn't found in Memcached. I'm trying to avoid passing in a "version" setting or similar for consumers of rubycas, and so seems like a simple check for whether the controller has env property should handle this. 

Tested a variation of this in sandbox and it seemed to resolve the issue, ~but needs more testing~ done: see below. Meanwhile putting this up for preliminary review.

@mdsol/team-28 @mdsol/team-07 

Sandbox Testing
==

without fix
--
using [this modified branch](https://github.com/mdsol/rubycas-client/compare/debug/error_situation_for_rails_5?expand=1) with logging and an induced cache fail, the error occurs exactly as seen in production:

sumo [logs](https://service.sumologic.com/ui/#/search/pH0ZSqHrgHBmQMBLoY8u8xfjkv7DJD7m5Bfh20XJ
) shows same error:
<img width="1128" alt="Screen Shot 2020-07-13 at 3 00 51 PM" src="https://user-images.githubusercontent.com/2036416/87342684-aae1cb00-c519-11ea-99d0-cf2db72481b3.png">


and full checkmate 404 error page renders, same error as in prod:
<img width="1772" alt="Screen Shot 2020-07-13 at 2 56 26 PM" src="https://user-images.githubusercontent.com/2036416/87342618-8e459300-c519-11ea-86fe-c4683d59f705.png">



with fix
--
using the same debug branch, but with the fix in place, the error goes away and [logs](https://service.sumologic.com/ui/#/search/uTfqspP9VkYqDPhse4ioIummYCmKftYFNkdtjb1l
) show that the code path went where the error would have otherwise occurred:

<img width="1016" alt="Screen Shot 2020-07-13 at 3 11 43 PM" src="https://user-images.githubusercontent.com/2036416/87344022-bc2bd700-c51b-11ea-84c0-02a1e5ce35ee.png">


and from above 302, the page loads as expected.

<img width="1772" alt="Screen Shot 2020-07-13 at 3 03 17 PM" src="https://user-images.githubusercontent.com/2036416/87342896-02803680-c51a-11ea-8e03-390ccb09a9e1.png">



