### PR TITLE
[MCC-680344] Fix session error on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # RubyCAS-Client Changelog
 
+## 3.0.7
+* Other
+  * Fix log issue where session lookups were being performed with null keys.
+
 ## 3.0.6
 * Other
   * Only use session object in Session.session_destroy if its available

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubycas-client (3.0.6)
+    rubycas-client (3.0.7)
       activesupport
       dalli (>= 2.0)
       dice_bag (>= 0.9, < 2.0)

--- a/lib/active_model_memcache_store.rb
+++ b/lib/active_model_memcache_store.rb
@@ -41,7 +41,7 @@ module ActionDispatch
               end
             else
               message = session.has_key?('service_ticket') ? "Service ticket key present, @pool.exist?: #{@pool.exist?(session['service_ticket'])}" : "Service ticket key is nil."
-              CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: #{message}");
+              CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: [SESSION #{session_id}] #{message}");
             end
           else
             CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: the retrieved pool session for session_id #{session_id} is nil");

--- a/lib/active_model_memcache_store.rb
+++ b/lib/active_model_memcache_store.rb
@@ -40,7 +40,7 @@ module ActionDispatch
                 raise if @raise_errors
               end
             else
-              CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: Session  #{session_id} has_key?: #{session.has_key?("service_ticket")}, @pool.exist?: #{@pool.exist?(session["service_ticket"])}");
+              CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: Session #{session_id} has_key?: #{session.has_key?('service_ticket')}, @pool.exist?: #{@pool.exist?(session['service_ticket'])}");
             end
           else
             CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: the retrieved pool session for session_id #{session_id} is nil");

--- a/lib/active_model_memcache_store.rb
+++ b/lib/active_model_memcache_store.rb
@@ -40,7 +40,8 @@ module ActionDispatch
                 raise if @raise_errors
               end
             else
-              CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: Session #{session_id} has_key?: #{session.has_key?('service_ticket')}, @pool.exist?: #{@pool.exist?(session['service_ticket'])}");
+              message = session.has_key?('service_ticket') ? "Service ticket key present, @pool.exist?: #{@pool.exist?(session['service_ticket'])}" : "Service ticket key is nil."
+              CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: #{message}");
             end
           else
             CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: the retrieved pool session for session_id #{session_id} is nil");

--- a/lib/casclient/version.rb
+++ b/lib/casclient/version.rb
@@ -1,3 +1,3 @@
 module CASClient #:nodoc:
-  VERSION = '3.0.6'.freeze
+  VERSION = '3.0.7'.freeze
 end

--- a/spec/casclient/active_model_memcache_store_spec.rb
+++ b/spec/casclient/active_model_memcache_store_spec.rb
@@ -29,7 +29,7 @@ describe ActionDispatch::Session::ActiveModelMemcacheStore do
       allow(CASClient::LoggerWrapper).to receive(:new).and_return(logger)
       allow_any_instance_of(ActiveSupport::Cache::DalliStore).to receive(:get).and_return( { "service_ticket" => "12345" } )
       allow_any_instance_of(ActiveSupport::Cache::DalliStore).to receive(:exist?).and_return(true, false)
-      expect(logger).to receive(:warn).with("Session::ActiveModelMemcacheStore#destroy_session: Service ticket key present, @pool.exist?: false")
+      expect(logger).to receive(:warn).with("Session::ActiveModelMemcacheStore#destroy_session: [SESSION 12345] Service ticket key present, @pool.exist?: false")
       expect { subject.destroy_session '','12345', {} }.not_to raise_error
     end
 

--- a/spec/casclient/active_model_memcache_store_spec.rb
+++ b/spec/casclient/active_model_memcache_store_spec.rb
@@ -29,7 +29,7 @@ describe ActionDispatch::Session::ActiveModelMemcacheStore do
       allow(CASClient::LoggerWrapper).to receive(:new).and_return(logger)
       allow_any_instance_of(ActiveSupport::Cache::DalliStore).to receive(:get).and_return( { "service_ticket" => "12345" } )
       allow_any_instance_of(ActiveSupport::Cache::DalliStore).to receive(:exist?).and_return(true, false)
-      expect(logger).to receive(:warn).with("Session::ActiveModelMemcacheStore#destroy_session: Session  12345 has_key?: true, @pool.exist?: false")
+      expect(logger).to receive(:warn).with("Session::ActiveModelMemcacheStore#destroy_session: Service ticket key present, @pool.exist?: false")
       expect { subject.destroy_session '','12345', {} }.not_to raise_error
     end
 

--- a/templates/active_model_memcache_store.rb
+++ b/templates/active_model_memcache_store.rb
@@ -42,7 +42,8 @@ module ActionDispatch
                 raise if @raise_errors
               end
             else
-              CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: Session #{session_id} has_key?: #{session.has_key?('service_ticket')}, @pool.exist?: #{@pool.exist?(session['service_ticket'])}");
+              message = session.has_key?('service_ticket') ? "Service ticket key present, @pool.exist?: #{@pool.exist?(session['service_ticket'])}" : "Service ticket key is nil."
+              CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: #{message}");
             end
           else
             CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: the retrieved pool session for session_id #{session_id} is nil");

--- a/templates/active_model_memcache_store.rb
+++ b/templates/active_model_memcache_store.rb
@@ -43,7 +43,7 @@ module ActionDispatch
               end
             else
               message = session.has_key?('service_ticket') ? "Service ticket key present, @pool.exist?: #{@pool.exist?(session['service_ticket'])}" : "Service ticket key is nil."
-              CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: #{message}");
+              CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: [SESSION #{session_id}] #{message}");
             end
           else
             CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: the retrieved pool session for session_id #{session_id} is nil");

--- a/templates/active_model_memcache_store.rb
+++ b/templates/active_model_memcache_store.rb
@@ -42,7 +42,7 @@ module ActionDispatch
                 raise if @raise_errors
               end
             else
-              CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: Session  #{session_id} has_key?: #{session.has_key?("service_ticket")}, @pool.exist?: #{@pool.exist?(session["service_ticket"])}");
+              CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: Session #{session_id} has_key?: #{session.has_key?('service_ticket')}, @pool.exist?: #{@pool.exist?(session['service_ticket'])}");
             end
           else
             CASClient::LoggerWrapper.new.warn("Session::ActiveModelMemcacheStore#destroy_session: the retrieved pool session for session_id #{session_id} is nil");


### PR DESCRIPTION
**Background**

As part of the changes made in an [earlier PR](https://github.com/mdsol/rubycas-client/pull/52) to address a `nil` key issue, we introduced some logging that became problematic if the session_id was null, because we were performing a lookup of the session based on that ID. This would lead to `ArgumentError` on lookup of the session, which would not fail gracefully and instead cause 500 errors on the client side when users would perform logouts under certain conditions.

**Changes**

- Split the log up to conditionally output the session existence value _only_ if the session ID was not null in the first place.
- Fixed associated specs.
- Upversioned to v3.0.7.