### PR TITLE
Create factbook.yaml

### DIFF
--- a/factbook.yaml
+++ b/factbook.yaml
@@ -20,7 +20,7 @@ metadata:
       email: team28@mdsol.com
   people:
     - role: architect
-      email: <TBD> 
+      email: cwhite@mdsol.com
   channels:
     - url: https://mdsol.slack.com/messages/C03B8T0AZGQ/details/
       automated_messaging: false

--- a/factbook.yaml
+++ b/factbook.yaml
@@ -11,9 +11,8 @@ metadata:
   title: RubyCAS Client
   description: RubyCAS-Client is a Ruby client library for Yale's Central Authentication Service (CAS) protocol.
   teams:
-    - name: Team 28
-      number: 28
-      email: team28@mdsol.com
+    - name: imedidata core team
+      email: imedidata-core-team@mdsol.com
   people:
     - role: architect
       email: cwhite@mdsol.com

--- a/factbook.yaml
+++ b/factbook.yaml
@@ -2,7 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 spec:
-  type: web_backend
+  type: library
   lifecycle: production
   owner: imedidata-core-team@mdsol.com
 metadata:

--- a/factbook.yaml
+++ b/factbook.yaml
@@ -4,7 +4,7 @@ kind: Component
 spec:
   type: web_backend
   lifecycle: production
-  owner: team28@mdsol.com
+  owner: imedidata-core-team@mdsol.com
 metadata:
   json_schema: https://github.com/mdsol/platform-standards/tree/master/schemas/v1alpha1.schema.json
   name: rubycas-client

--- a/factbook.yaml
+++ b/factbook.yaml
@@ -8,12 +8,8 @@ spec:
 metadata:
   json_schema: https://github.com/mdsol/platform-standards/tree/master/schemas/v1alpha1.schema.json
   name: rubycas-client
-  title: RubyCAS-Client
+  title: RubyCAS Client
   description: RubyCAS-Client is a Ruby client library for Yale's Central Authentication Service (CAS) protocol.
-  security:
-    authentication: [mauth]
-    network_accessiblity: [private]
-    data_types: [clinical]
   teams:
     - name: Team 28
       number: 28

--- a/factbook.yaml
+++ b/factbook.yaml
@@ -11,8 +11,8 @@ metadata:
   title: RubyCAS Client
   description: RubyCAS-Client is a Ruby client library for Yale's Central Authentication Service (CAS) protocol.
   teams:
-    - name: imedidata core team
-      email: imedidata-core-team@mdsol.com
+    - name: Team 28
+      number: 28
   people:
     - role: architect
       email: cwhite@mdsol.com

--- a/factbook.yaml
+++ b/factbook.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+spec:
+  type: web_backend
+  lifecycle: production
+  owner: team28@mdsol.com
+metadata:
+  json_schema: https://github.com/mdsol/platform-standards/tree/master/schemas/v1alpha1.schema.json
+  name: rubycas-client
+  title: RubyCAS-Client
+  description: RubyCAS-Client is a Ruby client library for Yale's Central Authentication Service (CAS) protocol.
+  security:
+    authentication: [mauth]
+    network_accessiblity: [private]
+    data_types: [clinical]
+  teams:
+    - name: Team 28
+      number: 28
+      email: team28@mdsol.com
+  people:
+    - role: architect
+      email: <TBD> 
+  channels:
+    - url: https://mdsol.slack.com/messages/C03B8T0AZGQ/details/
+      automated_messaging: false
+      role: slack
+  pipelines:
+    - url: https://travis-ci.com/github/mdsol/rubycas-client
+      role: Integration


### PR DESCRIPTION
Updating factbook to enable visibility in DevOps Central. The factbook is the source for information about your service, thus we need them filled in with accurate information. Your repo might not show up right away in DevOps Central because there is a delay in factbooks getting loaded into the system.

Please help us ensure the values are correct. Having the correct information enables useful information to be displayed about your service. This also helps you document your software and lets everyone understand our systems better.
