### PR TITLE
Remove activesupport, dally, redis-rack and dice_bag from runtime dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,13 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
+module TempFixForRakeLastComment
+  def last_comment
+    last_description
+  end
+end
+Rake::Application.send :include, TempFixForRakeLastComment
+
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec

--- a/lib/casclient.rb
+++ b/lib/casclient.rb
@@ -3,10 +3,12 @@ require 'cgi'
 require 'logger'
 require 'net/https'
 require 'rexml/document'
-require 'casclient/dice_bag/cas_template'
-require 'active_support'
-require 'active_model_memcache_store'
-require 'active_model_redis_store'
+
+# require 'casclient/dice_bag/cas_template'
+
+# require 'active_support'
+# require 'active_model_memcache_store'
+# require 'active_model_redis_store'
 
 $: << File.expand_path(File.dirname(__FILE__))
 

--- a/lib/casclient/version.rb
+++ b/lib/casclient/version.rb
@@ -1,3 +1,3 @@
 module CASClient #:nodoc:
-  VERSION = '3.2.0'.freeze
+  VERSION = '3.2.0-nodeps'.freeze
 end

--- a/rubycas-client.gemspec
+++ b/rubycas-client.gemspec
@@ -18,18 +18,17 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   s.require_paths = ["lib"]
 
-  # s.add_runtime_dependency 'activesupport', '>= 5.2', '< 7.1'
-  # s.add_runtime_dependency 'dalli', '~> 2.0'
-  # s.add_runtime_dependency 'dice_bag', '>= 0.9', '< 2.0'
-  # s.add_runtime_dependency 'redis-rack', '~> 2.1'
   s.add_runtime_dependency 'rexml'
 
   s.add_development_dependency 'actionpack', '>= 5.2', '< 7.1'
   s.add_development_dependency 'activerecord', '>= 5.2', '< 7.1'
   s.add_development_dependency 'activerecord-session_store', '>= 0'
+  s.add_development_dependency 'activesupport', '>= 5.2', '< 7.1'
   s.add_development_dependency 'appraisal', '~> 2.4'
   s.add_development_dependency 'bundler', '>= 1.0'
   s.add_development_dependency 'byebug'
+  s.add_development_dependency 'dalli', '~> 2.0'
+  s.add_development_dependency 'dice_bag', '>= 0.9', '< 2.0'
   s.add_development_dependency 'database_cleaner', '>= 0'
   s.add_development_dependency 'guard', '>= 0'
   s.add_development_dependency 'guard-rspec', '>= 0'
@@ -37,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '>= 0'
   s.add_development_dependency 'redis', '~> 4.5'
   s.add_development_dependency 'redis-actionpack', '~> 5.2'
+  s.add_development_dependency 'redis-rack', '~> 2.1'
   s.add_development_dependency 'redis-rails', '~> 5.0'
   s.add_development_dependency 'rspec', '~> 2.0'
   s.add_development_dependency 'simplecov', '>= 0'

--- a/rubycas-client.gemspec
+++ b/rubycas-client.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'activesupport', '>= 5.2', '< 7.1'
-  s.add_runtime_dependency 'dalli', '~> 2.0'
-  s.add_runtime_dependency 'dice_bag', '>= 0.9', '< 2.0'
-  s.add_runtime_dependency 'redis-rack', '~> 2.1'
+  # s.add_runtime_dependency 'activesupport', '>= 5.2', '< 7.1'
+  # s.add_runtime_dependency 'dalli', '~> 2.0'
+  # s.add_runtime_dependency 'dice_bag', '>= 0.9', '< 2.0'
+  # s.add_runtime_dependency 'redis-rack', '~> 2.1'
   s.add_runtime_dependency 'rexml'
 
   s.add_development_dependency 'actionpack', '>= 5.2', '< 7.1'


### PR DESCRIPTION
Hello,

I use your fork of rubycas-client without MemCached, nor Redis. 

It looks like these dependencies are optional and rubycas-clients works like a charm if these requires are commented out :

# require 'casclient/dice_bag/cas_template'
# require 'active_support'
# require 'active_model_memcache_store'
# require 'active_model_redis_store'

I moved these dependencies to the development dependencies so they get installed in a development environment and so, are available for testing.

I also fixed the Rakefile to allow old rspec to run with more recent ruby/rake.

Thank you for your work.

-- Pierre Y.